### PR TITLE
Mirror of phadej github#450

### DIFF
--- a/fixtures/pull-request-approved-review.json
+++ b/fixtures/pull-request-approved-review.json
@@ -1,0 +1,38 @@
+{
+  "id": 80,
+  "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
+  "user": {
+    "login": "octocat",
+    "id": 1,
+    "node_id": "MDQ6VXNlcjE=",
+    "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/octocat",
+    "html_url": "https://github.com/octocat",
+    "followers_url": "https://api.github.com/users/octocat/followers",
+    "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+    "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+    "organizations_url": "https://api.github.com/users/octocat/orgs",
+    "repos_url": "https://api.github.com/users/octocat/repos",
+    "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/octocat/received_events",
+    "type": "User",
+    "site_admin": false
+  },
+  "body": "Here is the body for the review.",
+  "state": "APPROVED",
+  "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
+  "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
+  "_links": {
+    "html": {
+      "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
+    },
+    "pull_request": {
+      "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
+    }
+  },
+  "submitted_at": "2019-11-17T17:43:43Z",
+  "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091"
+}

--- a/fixtures/pull-request-pending-review.json
+++ b/fixtures/pull-request-pending-review.json
@@ -1,0 +1,37 @@
+{
+  "id": 80,
+  "node_id": "MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=",
+  "user": {
+    "login": "octocat",
+    "id": 1,
+    "node_id": "MDQ6VXNlcjE=",
+    "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/octocat",
+    "html_url": "https://github.com/octocat",
+    "followers_url": "https://api.github.com/users/octocat/followers",
+    "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+    "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+    "organizations_url": "https://api.github.com/users/octocat/orgs",
+    "repos_url": "https://api.github.com/users/octocat/repos",
+    "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/octocat/received_events",
+    "type": "User",
+    "site_admin": false
+  },
+  "body": "Here is the body for the review.",
+  "state": "PENDING",
+  "html_url": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80",
+  "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/12",
+  "_links": {
+    "html": {
+      "href": "https://github.com/octocat/Hello-World/pull/12#pullrequestreview-80"
+    },
+    "pull_request": {
+      "href": "https://api.github.com/repos/octocat/Hello-World/pulls/12"
+    }
+  },
+  "commit_id": "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091"
+}

--- a/github.cabal
+++ b/github.cabal
@@ -46,6 +46,8 @@ extra-source-files:
   fixtures/list-teams.json
   fixtures/members-list.json
   fixtures/pull-request-opened.json
+  fixtures/pull-request-approved-review.json
+  fixtures/pull-request-pending-review.json
   fixtures/pull-request-review-requested.json
   fixtures/user-organizations.json
   fixtures/user.json
@@ -229,6 +231,7 @@ test-suite github-test
     GitHub.RateLimitSpec
     GitHub.ReleasesSpec
     GitHub.ReposSpec
+    GitHub.ReviewDecodeSpec
     GitHub.SearchSpec
     GitHub.UsersSpec
 

--- a/spec/GitHub/ReviewDecodeSpec.hs
+++ b/spec/GitHub/ReviewDecodeSpec.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell   #-}
+module GitHub.ReviewDecodeSpec where
+
+import Data.Aeson         (eitherDecodeStrict)
+import Data.Either.Compat (isRight)
+import Data.FileEmbed     (embedFile)
+import Test.Hspec
+       (Spec, describe, it, shouldSatisfy)
+
+import GitHub.Data (Review)
+
+spec :: Spec
+spec = do
+  describe "PENDING state" $ do
+    -- https://docs.github.com/en/rest/reference/pulls#create-a-review-for-a-pull-request
+    -- > Pull request reviews created in the PENDING state do not include the submitted_at property in the response.
+    it "decodes review when in submitted_at is missing" $ do
+      let reviewInfo = eitherDecodeStrict $(embedFile "fixtures/pull-request-pending-review.json") :: Either String Review
+      reviewInfo `shouldSatisfy` isRight
+
+  describe "Other states" $ do
+    it "decodes review" $ do
+      let reviewInfo = eitherDecodeStrict $(embedFile "fixtures/pull-request-approved-review.json") :: Either String Review
+      reviewInfo `shouldSatisfy` isRight

--- a/spec/GitHub/ReviewDecodeSpec.hs
+++ b/spec/GitHub/ReviewDecodeSpec.hs
@@ -15,7 +15,7 @@ spec = do
   describe "PENDING state" $ do
     -- https://docs.github.com/en/rest/reference/pulls#create-a-review-for-a-pull-request
     -- > Pull request reviews created in the PENDING state do not include the submitted_at property in the response.
-    it "decodes review when in submitted_at is missing" $ do
+    it "decodes review when submitted_at is missing" $ do
       let reviewInfo = eitherDecodeStrict $(embedFile "fixtures/pull-request-pending-review.json") :: Either String Review
       reviewInfo `shouldSatisfy` isRight
 

--- a/src/GitHub/Data/Reviews.hs
+++ b/src/GitHub/Data/Reviews.hs
@@ -35,7 +35,7 @@ data Review = Review
     { reviewBody :: !Text
     , reviewCommitId :: !Text
     , reviewState :: ReviewState
-    , reviewSubmittedAt :: !UTCTime
+    , reviewSubmittedAt :: !(Maybe UTCTime)
     , reviewPullRequestUrl :: !URL
     , reviewHtmlUrl :: !Text
     , reviewUser :: !SimpleUser
@@ -51,11 +51,11 @@ instance FromJSON Review where
     parseJSON =
         withObject "Review" $ \o ->
             Review <$> o .: "body" <*> o .: "commit_id" <*> o .: "state" <*>
-            o .: "submitted_at" <*>
-            o .: "pull_request_url" <*>
-            o .: "html_url" <*>
-            o .: "user" <*>
-            o .: "id"
+            o .:? "submitted_at" <*>
+            o .:  "pull_request_url" <*>
+            o .:  "html_url" <*>
+            o .:  "user" <*>
+            o .:  "id"
 
 data ReviewComment = ReviewComment
     { reviewCommentId :: !(Id ReviewComment)


### PR DESCRIPTION
Mirror of phadej github#450
The `submitted_at` field in the PullRequest Review is currently decoded as mandatory:

```
instance FromJSON Review where
    parseJSON =
        withObject "Review" $ \o ->
            Review <$> o .: "body" <*> o .: "commit_id" <*> o .: "state" <*>
            o .: "submitted_at" <*>
            o .: "pull_request_url" <*>
            o .: "html_url" <*>
            o .: "user" <*>
            o .: "id"
```

https://github.com/phadej/github/blob/1119ad464706810e9b7db47b93d0b6a46dafbda8/src/GitHub/Data/Reviews.hs#L50

The Github API documentation states that:
> Pull request reviews created in the PENDING state do not include the submitted_at property in the response.
> https://docs.github.com/en/rest/reference/pulls#create-a-review-for-a-pull-request

I was bitten by this bug on Friday, where I was retrieving a Review in PENDING state.

I'm happy to get some pointers on the implementation. 


