### PR TITLE
Mirror of phadej github#441

### DIFF
--- a/src/GitHub/Data/Webhooks/Validate.hs
+++ b/src/GitHub/Data/Webhooks/Validate.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE PackageImports #-}
 -----------------------------------------------------------------------------
 -- |
 -- License     :  BSD-3-Clause
@@ -12,7 +13,7 @@ module GitHub.Data.Webhooks.Validate (
 import GitHub.Internal.Prelude
 import Prelude ()
 
-import Crypto.Hash.SHA1 (hmac)
+import "cryptohash-sha1" Crypto.Hash.SHA1 (hmac)
 import Data.ByteString  (ByteString)
 
 import qualified Data.ByteString.Base16 as Hex

--- a/src/GitHub/Internal/Prelude.hs
+++ b/src/GitHub/Internal/Prelude.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE PackageImports #-}
 -----------------------------------------------------------------------------
 -- |
 -- License     :  BSD-3-Clause
@@ -58,4 +59,4 @@ import Data.Time.ISO8601        (formatISO8601)
 import Data.Vector              (Vector)
 import Data.Vector.Instances ()
 import GHC.Generics             (Generic)
-import Prelude.Compat
+import "base-compat" Prelude.Compat


### PR DESCRIPTION
Mirror of phadej github#441
This change is needed to use this library in [obelisk](https://github.com/obsidiansystems/obelisk) projects. It explicitly picks from one of these packages to resolve ambiguities. 

- cryptohash-sha1 vs cryptohash
- base-compat vs base-compat-batteries

Because, some user applications (like obelisk) will load this package (`github`) along with
other libraries with their own dependencies (creating a conflict) in the same GHCi repl.
